### PR TITLE
Set the displayName as writable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-gsap-enhancer",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Use the full power of React and GSAP together",
   "main": "lib/index.js",
   "directories": {

--- a/src/gsap-enhancer.js
+++ b/src/gsap-enhancer.js
@@ -156,7 +156,7 @@ function enhance (animationSourceMap, ComposedComponent) {
 
   const composedName = ComposedComponent.displayName || ComposedComponent.name || 'Component'
   const displayName = `GSAP(${composedName})`
-  Object.defineProperty(GSAPEnhancer, 'displayName', { value: displayName })
+  Object.defineProperty(GSAPEnhancer, 'displayName', { value: displayName, writable: true, configurable: true })
 
   return GSAPEnhancer
 }

--- a/test/gsap-enhancer/test.js
+++ b/test/gsap-enhancer/test.js
@@ -161,5 +161,18 @@ describe('gsap-enhancer', () => {
       const enhancedComponent = GSAP()(BaseComponent)
       assert(enhancedComponent.displayName === 'GSAP(BaseComponent)')
     })
+
+    it('is writable and configurable so that it can be overwritten', () => {
+      class BaseComponent extends Component {
+        render() {}
+      }
+      const enhancedComponent = GSAP()(BaseComponent)
+      const descriptor = Object.getOwnPropertyDescriptor(enhancedComponent, 'displayName')
+
+      assert(descriptor.configurable === true)
+      assert(descriptor.writable === true)
+      enhancedComponent.displayName = 'NewDisplayName'
+      assert(enhancedComponent.displayName === 'NewDisplayName')
+    })
   })
 })


### PR DESCRIPTION
Makes it so things like react-proxy (used when React Hot Loading) can overwrite the displayName.

gaearon/react-proxy#61